### PR TITLE
pass action args as meta to the factored actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
+.idea
 *.log
 lib

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "mocha --compilers js:babel-register test/*.js --require babel-polyfill",
     "prepublish": "npm run test && npm run build"
   },
-    "files": [
+  "files": [
     "lib",
     "src"
   ],


### PR DESCRIPTION
Pass arguments of the action call for for queries persistence
E.g.
```
export default handleActions({
  [loadMessages.START]: (state, action) => {
    const conversationId = action.payload[0];

    return ({
      ...state,
      conversationId,
      messages: {
        ...state.messages,
        requested: false,
        requesting: true,
        error: null
      }
    });
  },
  [loadMessages.SUCCEEDED]: (state, action) => {
    const conversationId = action.meta[0];

    // the result should belong to the last request
    if (conversationId !== state.conversationId) {
      return state;
    }

    return {
      ...state,
      messages: {
        ...state.messages,
        result: action.payload,
        requested: true,
        requesting: false
      }
    };
  },
```