### PR TITLE
feature(exceptions): add optional argument to suppress throwing exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,12 @@ then if the action throws it fails:
     }
 ```
 
+if you want to suppress throwing exceptions and instead handle errors 100% in the reducers, pass `true` as the 3rd argument
+
+```js
+const action = createActionThunk('FETCH', () => 3, true)
+```
+
 ### Metadata
 
 Sometimes you want to send metada with your actions

--- a/src/index.js
+++ b/src/index.js
@@ -3,9 +3,10 @@ import { createAction } from 'redux-actions';
 /**
  * Creates an async action creator
  *
- * @param  {String} TYPE    the type of the action
- * @param  {Function} fn    the function to be called async
- * @return {Funtion}        the action creator
+ * @param  {String} TYPE                 the type of the action
+ * @param  {Function} fn                 the function to be called async
+ * @param  {Boolean} suppressException   optionally do not throw exceptions
+ * @return {Funtion}                     the action creator
  */
 export function createActionThunk (type, fn, suppressException) {
   const TYPE_START     = `${type}_STARTED`;

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ import { createAction } from 'redux-actions';
  * @param  {Function} fn    the function to be called async
  * @return {Funtion}        the action creator
  */
-export function createActionThunk (type, fn) {
+export function createActionThunk (type, fn, suppressException) {
   const TYPE_START     = `${type}_STARTED`;
   const TYPE_SUCCEEDED = `${type}_SUCCEEDED`;
   const TYPE_FAILED    = `${type}_FAILED`;
@@ -43,7 +43,9 @@ export function createActionThunk (type, fn) {
       dispatch(actionCreators[TYPE_ENDED]({
         elapsed: endedAt - startedAt
       }));
-      throw err;
+      if(!suppressException) {
+        throw err;
+      }
     }
     try {
       result = fn(...args, {getState, dispatch, extra});


### PR DESCRIPTION
We ran into a few situations where it would have been advantageous to suppress throwing errors out of this library and instead handle it only in the reducers. This PR adds a third argument (boolean) to the thunk action creator where if present will bypass throwing the the error.